### PR TITLE
Strip the vendor'd section of the package path

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -89,3 +89,12 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 	}
 	return nil
 }
+
+// fixes vendored paths
+func fixPkgPathVendoring(pkgPath string) string {
+	const vendor = "/vendor/"
+	if i := strings.LastIndex(pkgPath, vendor); i != -1 {
+		return pkgPath[i+len(vendor):]
+	}
+	return pkgPath
+}

--- a/parser/parser_unix.go
+++ b/parser/parser_unix.go
@@ -22,9 +22,9 @@ func getPkgPath(fname string, isDir bool) (string, error) {
 		prefix := path.Join(p, "src") + "/"
 		if rel := strings.TrimPrefix(fname, prefix); rel != fname {
 			if !isDir {
-				return path.Dir(rel), nil
+				return fixPkgPathVendoring(path.Dir(rel)), nil
 			} else {
-				return path.Clean(rel), nil
+				return fixPkgPathVendoring(path.Clean(rel)), nil
 			}
 		}
 	}

--- a/parser/parser_windows.go
+++ b/parser/parser_windows.go
@@ -26,9 +26,9 @@ func getPkgPath(fname string, isDir bool) (string, error) {
 		prefix := path.Join(normalizePath(p), "src") + "/"
 		if rel := strings.TrimPrefix(fname, prefix); rel != fname {
 			if !isDir {
-				return path.Dir(rel), nil
+				return fixPkgPathVendoring(path.Dir(rel)), nil
 			} else {
-				return path.Clean(rel), nil
+				return fixPkgPathVendoring(path.Clean(rel)), nil
 			}
 		}
 	}


### PR DESCRIPTION
If the package that easyjson is being used on is vendor'd
then we need to strip off the vendor'd bit of the pkg path

Fixes: #29
See: golang/go#12739